### PR TITLE
#573 - mu: symbol-value should dereference ()

### DIFF
--- a/src/mu/types/symbol.rs
+++ b/src/mu/types/symbol.rs
@@ -415,7 +415,7 @@ impl CoreFunction for Symbol {
                     ));
                 }
             }
-            Type::Keyword => symbol,
+            Type::Keyword | Type::Null => symbol,
             _ => {
                 return Err(Exception::new(
                     env,


### PR DESCRIPTION
mu:symbol-value now dereferences ()

docs: no change
tests: no change
src: fix mu:symbol-value