### PR TITLE
#943 - runtime: destructure types

### DIFF
--- a/src/mu/core_/apply.rs
+++ b/src/mu/core_/apply.rs
@@ -91,7 +91,8 @@ impl Apply for Env {
                 match func.type_of() {
                     Type::Symbol => {
                         if Symbol::is_bound(self, func) {
-                            let fn_ = Symbol::value(self, func);
+                            let fn_ = Symbol::destruct(self, func).2;
+
                             match fn_.type_of() {
                                 Type::Function => self.apply(fn_, args),
                                 _ => Err(Exception::new(self, Condition::Type, "mu:eval", func))?,
@@ -106,7 +107,7 @@ impl Apply for Env {
             }
             Type::Symbol => {
                 if Symbol::is_bound(self, expr) {
-                    Ok(Symbol::value(self, expr))
+                    Ok(Symbol::destruct(self, expr).2)
                 } else {
                     Err(Exception::new(self, Condition::Unbound, "mu:eval", expr))?
                 }

--- a/src/mu/core_/core.rs
+++ b/src/mu/core_/core.rs
@@ -209,8 +209,8 @@ impl Core {
 
     // core/feature symbols
     pub fn symbols(env: &Env) {
-        let mu_id: u16 =
-            Fixnum::as_i64(Vector::ref_(env, Struct::vector(env, env.mu_ns), 0).unwrap()) as u16;
+        let (_, vector) = Struct::destruct(env, env.mu_ns);
+        let mu_id: u16 = Fixnum::as_i64(Vector::ref_(env, vector, 0).unwrap()) as u16;
 
         for (index, desc) in CORE_FUNCTIONS.iter().enumerate() {
             let (name, _, _) = desc;
@@ -235,8 +235,8 @@ impl Core {
                 Namespace::with_static(env, &feature.namespace, feature.symbols, feature.functions)
                     .unwrap();
 
-            let ns_id: u16 =
-                Fixnum::as_i64(Vector::ref_(env, Struct::vector(env, ns), 0).unwrap()) as u16;
+            let (_, vector) = Struct::destruct(env, ns);
+            let ns_id: u16 = Fixnum::as_i64(Vector::ref_(env, vector, 0).unwrap()) as u16;
 
             if let Some(functions) = feature.functions {
                 for (index, desc) in functions.iter().enumerate() {

--- a/src/mu/core_/lambda.rs
+++ b/src/mu/core_/lambda.rs
@@ -70,7 +70,7 @@ impl Lambda {
     fn lexical(env: &Env, symbol: Tag, lexical_env: &mut [Lambda]) -> exception::Result<Tag> {
         assert_eq!(symbol.type_of(), Type::Symbol);
 
-        let name = Vector::as_string(env, Symbol::name(env, symbol));
+        let name = Vector::as_string(env, Symbol::destruct(env, symbol).1);
         for frame in lexical_env.iter().rev() {
             let Lambda { function, symbols } = frame;
 
@@ -86,7 +86,8 @@ impl Lambda {
         }
 
         if Symbol::is_bound(env, symbol) {
-            let value = Symbol::value(env, symbol);
+            let value = Symbol::destruct(env, symbol).2;
+
             match value.type_of() {
                 Type::Cons | Type::Symbol => Ok(symbol),
                 _ => Ok(value),

--- a/src/mu/features/core.rs
+++ b/src/mu/features/core.rs
@@ -200,8 +200,8 @@ impl CoreFn for Feature {
         if Tag::null_(&ns) {
             ns = env.null_ns
         }
-
-        if !Struct::stype(env, ns).eq_(&Symbol::keyword("ns")) {
+        let (stype, _) = Struct::destruct(env, ns);
+        if !stype.eq_(&Symbol::keyword("ns")) {
             Err(Exception::new(env, Condition::Type, "mu:intern", ns))?
         }
 

--- a/src/mu/types/cons.rs
+++ b/src/mu/types/cons.rs
@@ -280,7 +280,7 @@ impl Cons {
         }
 
         match car.type_of() {
-            Type::Symbol if dot.eq_(&Symbol::name(env, car)) => {
+            Type::Symbol if dot.eq_(&Symbol::destruct(env, car).1) => {
                 let cdr = env.read(stream, false, Tag::nil(), true)?;
 
                 if EOL.eq_(&cdr) {

--- a/src/mu/types/function.rs
+++ b/src/mu/types/function.rs
@@ -33,7 +33,7 @@ use {
 #[derive(Copy, Clone)]
 pub struct Function {
     pub arity: Tag, // fixnum # of required arguments
-    pub form: Tag,  // dotted pair or list
+    pub form: Tag,  // list
 }
 
 pub trait Gc {
@@ -183,12 +183,12 @@ impl Function {
     }
 
     pub fn heap_size(env: &Env, func: Tag) -> usize {
-        let (_, form) = Self::destruct(env, func);
-
-        match form.type_of() {
+        match Function::destruct(env, func).1.type_of() {
             Type::Null | Type::Cons => std::mem::size_of::<Function>(),
             Type::Vector => std::mem::size_of::<Function>(),
-            Type::Symbol => std::mem::size_of::<Fixnum>() + Symbol::heap_size(env, form),
+            Type::Symbol => {
+                std::mem::size_of::<Fixnum>() + Symbol::heap_size(env, Self::destruct(env, func).1)
+            }
             _ => panic!(),
         }
     }


### PR DESCRIPTION
no more accessors, everything destructures. better error checking on namespace primitives.

docs: no change
tests: no change
srcs: add destructuring function to all compound types and use it. 