### PR TITLE
#976 - core: dangling symbol

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,8 @@ Usage: forge 0.0.18 command [option...]
                                        ; benchmark test suite
     regression                         ; regression test suite
     symbols   reference | crossref | metrics [--namespace=name]
-                                       ; symbol reports, module default to mu
+                                       ; symbol reports, namespace 
+                                       ; defaults to mu
     install                            ; (sudo) install mu system-wide
     clean                              ; clean all artifacts
     commit                             ; fmt and clippy, pre-commit checking

--- a/mu/sys/core/generic.l
+++ b/mu/sys/core/generic.l
@@ -44,7 +44,7 @@
                 (:if type-function
                      (core:apply type-function args)
                      (mu:raise-from type-function 'core:%apply-generic :type)))
-              (mu:cdr (core:find-if (:lambda (impl) (core:typep object (mu:car impl))) impls))))
+              (mu:cdr (core:find-if (:lambda (impl) (core:%typep object (mu:car impl))) impls))))
            (mu:car args)
            (mu:cdr (core:%generic-prop :impls generic)))
           (mu:raise-from generic 'core:%apply-generic :type))))

--- a/src/forge/src/main.rs
+++ b/src/forge/src/main.rs
@@ -35,7 +35,7 @@ pub fn usage() {
     println!("                                       ; benchmark test suite");
     println!("    regression                         ; regression test suite");
     println!("    symbols   reference | crossref | metrics [--namespace=name]");
-    println!("                                       ; symbol reports, module default to mu");
+    println!("                                       ; symbol reports, namespace defaults to mu");
     println!("    install                            ; (sudo) install mu system-wide");
     println!("    clean                              ; clean all artifacts");
     println!("    commit                             ; fmt and clippy, pre-commit checking");


### PR DESCRIPTION
We need to do a better job of testing code paths in core. Fix symbol typo, and adjust forge usage message.

docs: sync README and forge usage message
tests: no change
srcs: fix core typo and forge usage message