### PR TITLE
#991 - runtime: redo static namespaces

### DIFF
--- a/src/mu/core/core_.rs
+++ b/src/mu/core/core_.rs
@@ -150,7 +150,6 @@ pub struct Core {
     pub stdio: (Tag, Tag, Tag),
     pub stream_id: RwLock<u64>,
     pub streams: RwLock<HashMap<u64, RwLock<Stream>>>,
-    pub symbols: RwLock<HashMap<String, Tag>>,
 }
 
 impl Default for Core {
@@ -173,7 +172,6 @@ impl Core {
             stdio: (Tag::nil(), Tag::nil(), Tag::nil()),
             stream_id: RwLock::new(0),
             streams: RwLock::new(HashMap::new()),
-            symbols: RwLock::new(HashMap::new()),
         };
 
         core.stdio = (
@@ -183,19 +181,6 @@ impl Core {
         );
 
         core
-    }
-
-    // accessors
-    pub fn stdin(&self) -> Tag {
-        self.stdio.0
-    }
-
-    pub fn stdout(&self) -> Tag {
-        self.stdio.1
-    }
-
-    pub fn errout(&self) -> Tag {
-        self.stdio.2
     }
 
     pub fn map_core_function(func: Tag) -> CoreFnDef {
@@ -213,7 +198,6 @@ impl Core {
     pub fn intern_symbols(env: &Env) {
         for (index, desc) in CORE_FUNCTIONS.iter().enumerate() {
             Namespace::intern_static(env, env.mu_ns, (*desc.0).into(), DirectTag::function(index))
-                .unwrap();
         }
 
         let mut ndef = CORE_FUNCTIONS.len();
@@ -228,8 +212,7 @@ impl Core {
 
             if let Some(functions) = &feature.functions {
                 for desc in functions.iter() {
-                    Namespace::intern_static(env, ns, (desc.0).into(), DirectTag::function(ndef))
-                        .unwrap();
+                    Namespace::intern_static(env, ns, (desc.0).into(), DirectTag::function(ndef));
 
                     ndef += 1
                 }

--- a/src/mu/core/env.rs
+++ b/src/mu/core/env.rs
@@ -66,14 +66,13 @@ impl Env {
         };
 
         // establish namespaces
-        env.mu_ns = Namespace::with_static(&env, "mu", Some(CORE.symbols.clone())).unwrap();
+        env.mu_ns = Namespace::with_static(&env, "mu", Some(RwLock::new(HashMap::new()))).unwrap();
         env.keyword_ns = Namespace::with_static(&env, "keyword", None).unwrap();
 
         // standard streams
-        Namespace::intern_static(&env, env.mu_ns, "*standard-input*".into(), CORE.stdin()).unwrap();
-        Namespace::intern_static(&env, env.mu_ns, "*standard-output*".into(), CORE.stdout())
-            .unwrap();
-        Namespace::intern_static(&env, env.mu_ns, "*error-output*".into(), CORE.errout()).unwrap();
+        Namespace::intern_static(&env, env.mu_ns, "*standard-input*".into(), CORE.stdio.0);
+        Namespace::intern_static(&env, env.mu_ns, "*standard-output*".into(), CORE.stdio.1);
+        Namespace::intern_static(&env, env.mu_ns, "*error-output*".into(), CORE.stdio.2);
 
         // core symbols
         Core::intern_symbols(&env);

--- a/src/mu/features/core.rs
+++ b/src/mu/features/core.rs
@@ -181,7 +181,7 @@ impl CoreFn for Feature {
             .unwrap();
 
         let hash_ref = block_on(match ns_map {
-            Namespace::Static(static_) => match &static_.hash {
+            Namespace::Static(static_) => match &static_ {
                 Some(hash) => hash.read(),
                 None => {
                     fp.value = Tag::nil();

--- a/src/mu/lib.rs
+++ b/src/mu/lib.rs
@@ -162,17 +162,17 @@ impl Mu {
 
     /// return the standard-input core stream
     pub fn std_in() -> Tag {
-        CORE.stdin()
+        CORE.stdio.0
     }
 
     /// return the standard-output core stream
     pub fn std_out() -> Tag {
-        CORE.stdout()
+        CORE.stdio.1
     }
 
     /// return the error-output core stream
     pub fn err_out() -> Tag {
-        CORE.errout()
+        CORE.stdio.2
     }
 
     /// format exception

--- a/src/mu/namespaces/gc.rs
+++ b/src/mu/namespaces/gc.rs
@@ -91,7 +91,7 @@ impl Gc for GcContext<'_> {
 
         for (_, _, ns_cache) in &*ns_map_ref {
             let hash_ref = block_on(match ns_cache {
-                Namespace::Static(static_) => match &static_.hash {
+                Namespace::Static(static_) => match &static_ {
                     Some(hash) => hash.read(),
                     None => return,
                 },


### PR DESCRIPTION
no need for mutability on static symbol maps

docs: no change
tests: no change
srcs: revise static namespaces and some other core trimmings
