### PR TITLE
#1022 - runtime: fix backquote test failures

### DIFF
--- a/src/mu/reader/quasi.rs
+++ b/src/mu/reader/quasi.rs
@@ -180,9 +180,7 @@ impl QuasiReader {
                 "mu:read",
             ))?,
             Some(syntax) => match syntax {
-                QuasiSyntax::Atom | QuasiSyntax::Comma => {
-                    Ok(QuasiExpr::Comma(self.read_form(env)?))
-                }
+                QuasiSyntax::Comma => Ok(QuasiExpr::Comma(self.read_form(env)?)),
                 QuasiSyntax::CommaAt => Err(Exception::err(
                     env,
                     Symbol::keyword(",@"),
@@ -209,7 +207,9 @@ impl QuasiReader {
                         _ => Ok(expr),
                     }
                 }
-                QuasiSyntax::Quasi => Ok(QuasiExpr::Basic(self.read_form(env)?)),
+                QuasiSyntax::Atom | QuasiSyntax::Quasi => {
+                    Ok(QuasiExpr::Basic(self.read_form(env)?))
+                }
             },
         }
     }


### PR DESCRIPTION
somehow the quasiquote logic got messed up

docs: no change
tests: mu quasiquote tests back to normal
src: fiddle quasiquote parser