### PR TITLE
#1029: runtime - consolidate gc

### DIFF
--- a/src/mu/core/core_.rs
+++ b/src/mu/core/core_.rs
@@ -14,10 +14,8 @@ use {
             tag::{CoreFn as _, Tag},
         },
         features::feature::{Feature, FEATURES},
-        namespaces::{
-            gc::{CoreFn as _, GcContext},
-            namespace::{CoreFn as _, Namespace},
-        },
+        gc::gc_::{CoreFn as _, GcContext},
+        namespaces::namespace::{CoreFn as _, Namespace},
         streams::builder::StreamBuilder,
         types::{
             cons::{Cons, CoreFn as _},

--- a/src/mu/features/instrument.rs
+++ b/src/mu/features/instrument.rs
@@ -82,7 +82,13 @@ impl CoreFn for Feature {
         } else if cmd.eq_(&Symbol::keyword("get")) {
             let prof_vec = (*profile_map_ref)
                 .iter()
-                .map(|item| Cons::cons(env, item.0, Fixnum::with_u64(env, item.1, "instrument:control").unwrap()))
+                .map(|item| {
+                    Cons::cons(
+                        env,
+                        item.0,
+                        Fixnum::with_u64(env, item.1, "instrument:control").unwrap(),
+                    )
+                })
                 .collect::<Vec<Tag>>();
 
             fp.value = Vector::from(prof_vec).with_heap(env)

--- a/src/mu/gc/async_.rs
+++ b/src/mu/gc/async_.rs
@@ -1,0 +1,60 @@
+//  SPDX-FileCopyrightText: Copyright 2022 James M. Putnam (putnamjm.design@gmail.com)
+//  SPDX-License-Identifier: MIT
+
+// async function type
+use crate::{
+    core::{env::Env, tag::Tag, type_::Type},
+    gc::gc_::{Gc as _, GcContext},
+    types::async_::Async,
+};
+
+pub trait Gc {
+    fn ref_form(_: &mut GcContext, _: Tag) -> Tag;
+    fn mark(_: &mut GcContext, _: &Env, _: Tag);
+    fn gc_ref_image(_: &mut GcContext, _: Tag) -> Self;
+}
+
+impl Gc for Async {
+    fn ref_form(context: &mut GcContext, func: Tag) -> Tag {
+        Self::gc_ref_image(context, func).form
+    }
+
+    fn mark(context: &mut GcContext, env: &Env, function: Tag) {
+        let mark = context.mark_image(function).unwrap();
+
+        if !mark {
+            let form = Self::ref_form(context, function);
+
+            context.mark(env, form);
+        }
+    }
+
+    fn gc_ref_image(context: &mut GcContext, tag: Tag) -> Self {
+        let heap_ref = &context.heap_ref;
+
+        assert_eq!(tag.type_of(), Type::Async);
+        match tag {
+            Tag::Indirect(fn_) => Async {
+                arity: Tag::from_slice(
+                    heap_ref
+                        .image_slice(usize::try_from(fn_.image_id()).unwrap())
+                        .unwrap(),
+                ),
+                form: Tag::from_slice(
+                    heap_ref
+                        .image_slice(usize::try_from(fn_.image_id()).unwrap() + 1)
+                        .unwrap(),
+                ),
+            },
+            Tag::Direct(_) => panic!(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn as_tag() {
+        assert_eq!(true, true)
+    }
+}

--- a/src/mu/gc/cons.rs
+++ b/src/mu/gc/cons.rs
@@ -1,0 +1,92 @@
+//  SPDX-FileCopyrightText: Copyright 2022 James M. Putnam (putnamjm.design@gmail.com)
+//  SPDX-License-Identifier: MIT
+
+//! cons type
+use crate::{
+    core::{direct::DirectTag, env::Env, tag::Tag, type_::Type},
+    gc::gc_::{Gc as _, GcContext},
+    types::cons::Cons,
+};
+
+pub trait Gc {
+    fn gc_ref_image(_: &GcContext, tag: Tag) -> Self;
+    fn ref_car(_: &GcContext, _: Tag) -> Tag;
+    fn ref_cdr(_: &GcContext, _: Tag) -> Tag;
+    fn mark(_: &mut GcContext, _: &Env, _: Tag);
+}
+
+impl Gc for Cons {
+    fn gc_ref_image(context: &GcContext, tag: Tag) -> Self {
+        let heap_ref = &context.heap_ref;
+
+        assert_eq!(tag.type_of(), Type::Cons);
+        match tag {
+            Tag::Indirect(main) => Cons {
+                car: Tag::from_slice(
+                    heap_ref
+                        .image_slice(usize::try_from(main.image_id()).unwrap())
+                        .unwrap(),
+                ),
+                cdr: Tag::from_slice(
+                    heap_ref
+                        .image_slice(usize::try_from(main.image_id()).unwrap() + 1)
+                        .unwrap(),
+                ),
+            },
+            Tag::Direct(_) => panic!(),
+        }
+    }
+
+    fn ref_car(context: &GcContext, cons: Tag) -> Tag {
+        match cons.type_of() {
+            Type::Null => cons,
+            Type::Cons => match cons {
+                Tag::Direct(_) => DirectTag::cons_destruct(cons).0,
+                Tag::Indirect(_) => Self::gc_ref_image(context, cons).car,
+            },
+            _ => panic!(),
+        }
+    }
+
+    fn ref_cdr(context: &GcContext, cons: Tag) -> Tag {
+        match cons.type_of() {
+            Type::Null => cons,
+            Type::Cons => match cons {
+                Tag::Indirect(_) => Self::gc_ref_image(context, cons).cdr,
+                Tag::Direct(_) => DirectTag::cons_destruct(cons).1,
+            },
+            _ => panic!(),
+        }
+    }
+
+    fn mark(context: &mut GcContext, env: &Env, cons: Tag) {
+        match cons {
+            Tag::Direct(_) => {
+                let car = Self::ref_car(context, cons);
+                let cdr = Self::ref_cdr(context, cons);
+
+                context.mark(env, car);
+                context.mark(env, cdr);
+            }
+            Tag::Indirect(_) => {
+                let mark = context.mark_image(cons).unwrap();
+                if !mark {
+                    context.mark(env, Self::ref_car(context, cons));
+                    context.mark(env, Self::ref_cdr(context, cons));
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{core::tag::Tag, types::cons::Cons};
+
+    #[test]
+    fn cons_test() {
+        match Cons::new(Tag::nil(), Tag::nil()) {
+            _ => assert!(true),
+        }
+    }
+}

--- a/src/mu/gc/function.rs
+++ b/src/mu/gc/function.rs
@@ -1,0 +1,70 @@
+//  SPDX-FileCopyrightText: Copyright 2022 James M. Putnam (putnamjm.design@gmail.com)
+//  SPDX-License-Identifier: MIT
+
+// function type
+#[rustfmt::skip]
+use {
+    crate::{
+        core::{
+            env::Env,
+            tag::{Tag},
+            type_::Type,
+        },
+        gc::gc_::{Gc as _, GcContext},
+        types::{
+            function::Function,
+        },
+    },
+};
+
+pub trait Gc {
+    fn ref_form(_: &mut GcContext, _: Tag) -> Tag;
+    fn mark(_: &mut GcContext, _: &Env, _: Tag);
+    fn gc_ref_image(_: &mut GcContext, _: Tag) -> Self;
+}
+
+impl Gc for Function {
+    fn ref_form(context: &mut GcContext, func: Tag) -> Tag {
+        Self::gc_ref_image(context, func).form
+    }
+
+    fn mark(context: &mut GcContext, env: &Env, function: Tag) {
+        let mark = context.mark_image(function).unwrap();
+
+        if !mark {
+            let form = Self::ref_form(context, function);
+
+            context.mark(env, form);
+        }
+    }
+
+    fn gc_ref_image(context: &mut GcContext, tag: Tag) -> Self {
+        assert_eq!(tag.type_of(), Type::Function);
+
+        let heap_ref = &context.heap_ref;
+
+        match tag {
+            Tag::Indirect(fn_) => Self::new(
+                Tag::from_slice(
+                    heap_ref
+                        .image_slice(usize::try_from(fn_.image_id()).unwrap())
+                        .unwrap(),
+                ),
+                Tag::from_slice(
+                    heap_ref
+                        .image_slice(usize::try_from(fn_.image_id()).unwrap() + 1)
+                        .unwrap(),
+                ),
+            ),
+            Tag::Direct(_) => panic!(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn as_tag() {
+        assert!(true)
+    }
+}

--- a/src/mu/gc/gc_.rs
+++ b/src/mu/gc/gc_.rs
@@ -5,19 +5,18 @@
 #![allow(dead_code)]
 use crate::{
     core::{env::Env, exception, frame::Frame, tag::Tag, type_::Type},
+    gc::{
+        async_::Gc as _, cons::Gc as _, function::Gc as _, struct_::Gc as _, symbol::Gc as _,
+        vector::Gc as _,
+    },
     namespaces::{
         heap::{Gc as _, Heap},
         namespace::Namespace,
     },
     types::{
-        async_::{Async, Gc as _},
-        cons::{Cons, Gc as _},
-        function::{Function, Gc as _},
-        struct_::{Gc as _, Struct},
-        symbol::{Gc as _, Symbol},
+        async_::Async, cons::Cons, function::Function, struct_::Struct, symbol::Symbol,
         vector::Vector,
     },
-    vectors::vector::Gc as _,
 };
 
 use futures_lite::future::block_on;

--- a/src/mu/gc/mod.rs
+++ b/src/mu/gc/mod.rs
@@ -1,0 +1,12 @@
+//  SPDX-FileCopyrightText: Copyright 2022 James M. Putnam (putnamjm.design@gmail.com)
+//  SPDX-License-Identifier: MIT
+
+//! gc
+pub mod async_;
+pub mod cons;
+pub mod function;
+pub mod gc_;
+pub mod namespace;
+pub mod struct_;
+pub mod symbol;
+pub mod vector;

--- a/src/mu/gc/namespace.rs
+++ b/src/mu/gc/namespace.rs
@@ -1,0 +1,47 @@
+//  SPDX-FileCopyrightText: Copyright 2022 James M. Putnam (putnamjm.design@gmail.com)
+//  SPDX-License-Identifier: MIT
+
+// namespaces
+use {
+    crate::{
+        core::env::Env,
+        gc::{gc_::GcContext, symbol::Gc as _},
+        namespaces::namespace::Namespace,
+        types::symbol::Symbol,
+    },
+    futures_lite::future::block_on,
+};
+
+pub trait Gc {
+    #[allow(dead_code)]
+    fn gc(&mut self, _: &mut GcContext, _: &Env);
+}
+
+impl Gc for Namespace {
+    #[allow(dead_code)]
+    fn gc(&mut self, gc: &mut GcContext, env: &Env) {
+        match self {
+            Namespace::Static(static_) => {
+                if let Some(hash) = &static_ {
+                    for symbol in hash.values() {
+                        Symbol::mark(gc, env, *symbol);
+                    }
+                }
+            }
+            Namespace::Dynamic(ref hash) => {
+                let hash_ref = block_on(hash.read());
+                for symbol in hash_ref.values() {
+                    Symbol::mark(gc, env, *symbol);
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn namespace_test() {
+        assert!(true)
+    }
+}

--- a/src/mu/gc/struct_.rs
+++ b/src/mu/gc/struct_.rs
@@ -1,0 +1,56 @@
+//  SPDX-FileCopyrightText: Copyright 2022 James M. Putnam (putnamjm.design@gmail.com)
+//  SPDX-License-Identifier: MIT
+
+// struct type
+use crate::{
+    core::{env::Env, tag::Tag, type_::Type},
+    gc::gc_::{Gc as _, GcContext},
+    types::struct_::Struct,
+};
+
+pub trait Gc {
+    fn gc_ref_image(_: &mut GcContext, tag: Tag) -> Self;
+    fn mark(_: &mut GcContext, env: &Env, struct_: Tag);
+}
+
+impl Gc for Struct {
+    fn gc_ref_image(context: &mut GcContext, tag: Tag) -> Self {
+        assert_eq!(tag.type_of(), Type::Struct);
+
+        let heap_ref = &context.heap_ref;
+
+        match tag {
+            Tag::Indirect(image) => Struct {
+                stype: Tag::from_slice(
+                    heap_ref
+                        .image_slice(usize::try_from(image.image_id()).unwrap())
+                        .unwrap(),
+                ),
+                vector: Tag::from_slice(
+                    heap_ref
+                        .image_slice(usize::try_from(image.image_id()).unwrap() + 1)
+                        .unwrap(),
+                ),
+            },
+            Tag::Direct(_) => panic!(),
+        }
+    }
+
+    fn mark(context: &mut GcContext, env: &Env, struct_: Tag) {
+        let mark = context.mark_image(struct_).unwrap();
+
+        if !mark {
+            let vector = Self::gc_ref_image(context, struct_).vector;
+
+            context.mark(env, vector);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn struct_test() {
+        assert!(true);
+    }
+}

--- a/src/mu/gc/symbol.rs
+++ b/src/mu/gc/symbol.rs
@@ -1,0 +1,99 @@
+//  SPDX-FileCopyrightText: Copyright 2022 James M. Putnam (putnamjm.design@gmail.com)
+//  SPDX-License-Identifier: MIT
+
+// symbol type
+use crate::{
+    core::{
+        direct::{DirectExt, DirectTag, DirectType},
+        env::Env,
+        tag::Tag,
+        type_::Type,
+    },
+    gc::gc_::{Gc as _, GcContext},
+    types::symbol::{Symbol, SymbolImage},
+};
+
+pub trait Gc {
+    fn gc_ref_image(_: &mut GcContext, tag: Tag) -> SymbolImage;
+    fn ref_name(_: &mut GcContext, symbol: Tag) -> Tag;
+    fn ref_value(_: &mut GcContext, symbol: Tag) -> Tag;
+    fn mark(_: &mut GcContext, env: &Env, symbol: Tag);
+}
+
+impl Gc for Symbol {
+    fn gc_ref_image(context: &mut GcContext, tag: Tag) -> SymbolImage {
+        assert_eq!(tag.type_of(), Type::Symbol);
+
+        match tag {
+            Tag::Indirect(main) => SymbolImage {
+                namespace: Tag::from_slice(
+                    context
+                        .heap_ref
+                        .image_slice(usize::try_from(main.image_id()).unwrap())
+                        .unwrap(),
+                ),
+                name: Tag::from_slice(
+                    context
+                        .heap_ref
+                        .image_slice(usize::try_from(main.image_id()).unwrap() + 1)
+                        .unwrap(),
+                ),
+                value: Tag::from_slice(
+                    context
+                        .heap_ref
+                        .image_slice(usize::try_from(main.image_id()).unwrap() + 2)
+                        .unwrap(),
+                ),
+            },
+            Tag::Direct(_) => panic!(),
+        }
+    }
+
+    fn ref_name(context: &mut GcContext, symbol: Tag) -> Tag {
+        match symbol.type_of() {
+            Type::Null | Type::Keyword => match symbol {
+                Tag::Direct(dir) => DirectTag::to_tag(
+                    dir.data(),
+                    DirectExt::Length(dir.ext() as usize),
+                    DirectType::String,
+                ),
+                Tag::Indirect(_) => panic!(),
+            },
+            Type::Symbol => Self::gc_ref_image(context, symbol).name,
+            _ => panic!(),
+        }
+    }
+
+    fn ref_value(context: &mut GcContext, symbol: Tag) -> Tag {
+        match symbol.type_of() {
+            Type::Null | Type::Keyword => symbol,
+            Type::Symbol => Self::gc_ref_image(context, symbol).value,
+            _ => panic!(),
+        }
+    }
+
+    fn mark(context: &mut GcContext, env: &Env, symbol: Tag) {
+        match symbol {
+            Tag::Direct(_) => (),
+            Tag::Indirect(_) => {
+                let mark = context.mark_image(symbol).unwrap();
+
+                if !mark {
+                    let name = Self::ref_name(context, symbol);
+                    let value = Self::ref_value(context, symbol);
+
+                    context.mark(env, name);
+                    context.mark(env, value);
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn symbol_test() {
+        assert!(true);
+    }
+}

--- a/src/mu/gc/vector.rs
+++ b/src/mu/gc/vector.rs
@@ -1,0 +1,202 @@
+//  SPDX-FileCopyrightText: Copyright 2022 James M. Putnam (putnamjm.design@gmail.com)
+//  SPDX-License-Identifier: MIT
+
+//! typed vectors
+use crate::{
+    core::{direct::DirectType, env::Env, tag::Tag, type_::Type},
+    gc::gc_::{Gc as _, GcContext},
+    types::{
+        fixnum::Fixnum,
+        vector::{Vector, VTYPEMAP},
+    },
+    vectors::image::{VecImage, VecImageType, VectorImage},
+};
+
+pub trait Gc {
+    fn gc_image_ref(_: &mut GcContext, _: Tag, _: usize) -> Option<Tag>;
+    fn gc_ref_image(_: &mut GcContext, _: Tag) -> VectorImage;
+    fn gc_ref(_: &mut GcContext, _: &Env, _: Tag, _: usize) -> Option<Tag>;
+    fn ref_type_of(_: &mut GcContext, _: Tag) -> Type;
+    fn ref_length(_: &mut GcContext, _: Tag) -> usize;
+    fn mark(_: &mut GcContext, _: &Env, _: Tag);
+}
+
+impl Gc for Vector {
+    fn gc_image_ref(context: &mut GcContext, vector: Tag, index: usize) -> Option<Tag> {
+        let image = Vector::gc_ref_image(context, vector);
+
+        if index >= usize::try_from(Fixnum::as_i64(image.length)).unwrap() {
+            None?;
+        }
+
+        let Tag::Indirect(vimage) = vector else {
+            panic!()
+        };
+
+        match Vector::to_type(image.type_).unwrap() {
+            Type::Byte => {
+                let slice = context
+                    .heap_ref
+                    .image_data_slice(
+                        usize::try_from(vimage.image_id()).unwrap()
+                            + <VecImageType<'_> as VecImage>::IMAGE_LEN,
+                        index,
+                        1,
+                    )
+                    .unwrap();
+
+                Some(slice[0].into())
+            }
+            Type::Char => {
+                let slice = context
+                    .heap_ref
+                    .image_data_slice(
+                        usize::try_from(vimage.image_id()).unwrap()
+                            + <VecImageType<'_> as VecImage>::IMAGE_LEN,
+                        index,
+                        1,
+                    )
+                    .unwrap();
+
+                let ch: char = slice[0].into();
+
+                Some(ch.into())
+            }
+            Type::T => Some(Tag::from_slice(
+                context
+                    .heap_ref
+                    .image_data_slice(
+                        usize::try_from(vimage.image_id()).unwrap()
+                            + <VecImageType<'_> as VecImage>::IMAGE_LEN,
+                        index * 8,
+                        8,
+                    )
+                    .unwrap(),
+            )),
+            Type::Fixnum => {
+                let slice = context
+                    .heap_ref
+                    .image_data_slice(
+                        usize::try_from(vimage.image_id()).unwrap()
+                            + <VecImageType<'_> as VecImage>::IMAGE_LEN,
+                        index * 8,
+                        8,
+                    )
+                    .unwrap();
+
+                Some(Fixnum::with_i64_or_panic(i64::from_le_bytes(
+                    slice[0..8].try_into().unwrap(),
+                )))
+            }
+            Type::Float => {
+                let slice = context
+                    .heap_ref
+                    .image_data_slice(
+                        usize::try_from(vimage.image_id()).unwrap()
+                            + <VecImageType<'_> as VecImage>::IMAGE_LEN,
+                        index * 4,
+                        4,
+                    )
+                    .unwrap();
+
+                Some(f32::from_le_bytes(slice[0..4].try_into().unwrap()).into())
+            }
+            _ => panic!(),
+        }
+    }
+
+    fn gc_ref_image(context: &mut GcContext, tag: Tag) -> VectorImage {
+        let heap_ref = &context.heap_ref;
+
+        match tag.type_of() {
+            Type::Vector => match tag {
+                Tag::Indirect(image) => VectorImage {
+                    type_: Tag::from_slice(
+                        heap_ref
+                            .image_slice(usize::try_from(image.image_id()).unwrap())
+                            .unwrap(),
+                    ),
+                    length: Tag::from_slice(
+                        heap_ref
+                            .image_slice(usize::try_from(image.image_id()).unwrap() + 1)
+                            .unwrap(),
+                    ),
+                },
+                Tag::Direct(_) => panic!(),
+            },
+            _ => panic!(),
+        }
+    }
+
+    fn gc_ref(context: &mut GcContext, env: &Env, vector: Tag, index: usize) -> Option<Tag> {
+        match vector.type_of() {
+            Type::Vector => match vector {
+                Tag::Direct(_direct) => {
+                    let ch: char = vector.data(env).to_le_bytes()[index].into();
+
+                    Some(ch.into())
+                }
+                Tag::Indirect(_) => <Vector as Gc>::gc_image_ref(context, vector, index),
+            },
+            _ => panic!(),
+        }
+    }
+
+    fn ref_type_of(context: &mut GcContext, vector: Tag) -> Type {
+        match vector {
+            Tag::Direct(direct) => match direct.dtype() {
+                DirectType::String => Type::Char,
+                DirectType::ByteVec => Type::Byte,
+                _ => panic!(),
+            },
+            Tag::Indirect(_) => {
+                let image = Self::gc_ref_image(context, vector);
+
+                match VTYPEMAP
+                    .iter()
+                    .copied()
+                    .find(|desc| image.type_.eq_(&desc.0))
+                {
+                    Some(desc) => desc.1,
+                    None => panic!(),
+                }
+            }
+        }
+    }
+
+    fn ref_length(context: &mut GcContext, vector: Tag) -> usize {
+        match vector {
+            Tag::Direct(direct) => direct.ext() as usize,
+            Tag::Indirect(_) => {
+                let image = Self::gc_ref_image(context, vector);
+
+                usize::try_from(Fixnum::as_i64(image.length)).unwrap()
+            }
+        }
+    }
+
+    fn mark(context: &mut GcContext, env: &Env, vector: Tag) {
+        match vector {
+            Tag::Direct(_) => (),
+            Tag::Indirect(_) => {
+                let marked = context.mark_image(vector).unwrap();
+
+                if !marked && Self::ref_type_of(context, vector) == Type::T {
+                    for index in 0..Self::ref_length(context, vector) {
+                        let value = Self::gc_ref(context, env, vector, index).unwrap();
+
+                        context.mark(env, value);
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn vector_test() {
+        assert!(true);
+    }
+}

--- a/src/mu/lib.rs
+++ b/src/mu/lib.rs
@@ -48,6 +48,7 @@ extern crate modular_bitfield;
 
 mod core;
 mod features;
+mod gc;
 mod namespaces;
 mod reader;
 mod streams;

--- a/src/mu/namespaces/mod.rs
+++ b/src/mu/namespaces/mod.rs
@@ -3,7 +3,6 @@
 
 // namespaces
 pub mod cache;
-pub mod gc;
 pub mod heap;
 pub mod namespace;
 
@@ -25,32 +24,4 @@ use {
         },
         namespaces::{heap::Heap, cache::Cache},
     },
-    // super::{heap::Heap, cache::Cache},
 };
-
-/*
-pub enum Space {
-    Heap,
-    Cache
-}
-
-impl Space for Heap {
-    fn allocate(&self) -> Tag {
-        Tag::nil()
-    }
-}
-
-impl Space for Cache {
-    fn allocate(&self) -> Tag {
-        Tag::nil()
-    }
-}
-
-pub trait Space {
-    fn allocate(&self) -> Tag;
-
-    fn alloc<T: Default>(env: &Env, space: Space) -> Tag {
-        .allocate()
-    }
-}
-*/

--- a/src/mu/namespaces/namespace.rs
+++ b/src/mu/namespaces/namespace.rs
@@ -14,43 +14,12 @@ use {
             tag::Tag,
             type_::Type,
         },
-        namespaces::gc::GcContext,
-        types::{
-            struct_::Struct,
-            symbol::{Gc as _, Symbol},
-            vector::Vector,
-        },
+        types::{struct_::Struct, symbol::Symbol, vector::Vector},
     },
     futures_lite::future::block_on,
     futures_locks::RwLock,
     std::{collections::HashMap, str},
 };
-
-pub trait Gc {
-    #[allow(dead_code)]
-    fn gc(&mut self, _: &mut GcContext, _: &Env);
-}
-
-impl Gc for Namespace {
-    #[allow(dead_code)]
-    fn gc(&mut self, gc: &mut GcContext, env: &Env) {
-        match self {
-            Namespace::Static(static_) => {
-                if let Some(hash) = &static_ {
-                    for symbol in hash.values() {
-                        Symbol::mark(gc, env, *symbol);
-                    }
-                }
-            }
-            Namespace::Dynamic(ref hash) => {
-                let hash_ref = block_on(hash.read());
-                for symbol in hash_ref.values() {
-                    Symbol::mark(gc, env, *symbol);
-                }
-            }
-        }
-    }
-}
 
 #[derive(Clone)]
 pub enum Namespace {

--- a/src/mu/types/async_.rs
+++ b/src/mu/types/async_.rs
@@ -11,10 +11,7 @@ use {
             tag::{Tag, TagType},
             type_::Type,
         },
-        namespaces::{
-            gc::{Gc as _, GcContext},
-            heap::HeapRequest,
-        },
+        namespaces::heap::HeapRequest,
         streams::writer::StreamWriter,
         types::{cons::Cons, fixnum::Fixnum, symbol::Symbol, vector::Vector},
     },
@@ -25,49 +22,6 @@ use {
 pub struct Async {
     pub arity: Tag,
     pub form: Tag,
-}
-
-pub trait Gc {
-    fn ref_form(_: &mut GcContext, _: Tag) -> Tag;
-    fn mark(_: &mut GcContext, _: &Env, _: Tag);
-    fn gc_ref_image(_: &mut GcContext, _: Tag) -> Self;
-}
-
-impl Gc for Async {
-    fn ref_form(context: &mut GcContext, func: Tag) -> Tag {
-        Self::gc_ref_image(context, func).form
-    }
-
-    fn mark(context: &mut GcContext, env: &Env, function: Tag) {
-        let mark = context.mark_image(function).unwrap();
-
-        if !mark {
-            let form = Self::ref_form(context, function);
-
-            context.mark(env, form);
-        }
-    }
-
-    fn gc_ref_image(context: &mut GcContext, tag: Tag) -> Self {
-        let heap_ref = &context.heap_ref;
-
-        assert_eq!(tag.type_of(), Type::Async);
-        match tag {
-            Tag::Indirect(fn_) => Async {
-                arity: Tag::from_slice(
-                    heap_ref
-                        .image_slice(usize::try_from(fn_.image_id()).unwrap())
-                        .unwrap(),
-                ),
-                form: Tag::from_slice(
-                    heap_ref
-                        .image_slice(usize::try_from(fn_.image_id()).unwrap() + 1)
-                        .unwrap(),
-                ),
-            },
-            Tag::Direct(_) => panic!(),
-        }
-    }
 }
 
 impl Async {

--- a/src/mu/types/cons.rs
+++ b/src/mu/types/cons.rs
@@ -14,10 +14,7 @@ use {
             tag::{Tag, TagType},
             type_::Type,
         },
-        namespaces::{
-            gc::{Gc as _, GcContext},
-            heap::HeapRequest,
-        },
+        namespaces::heap::HeapRequest,
         reader::read::{Reader, EOL},
         streams::writer::StreamWriter,
         types::{fixnum::Fixnum, symbol::Symbol, vector::Vector},
@@ -27,79 +24,8 @@ use {
 
 #[derive(Copy, Clone)]
 pub struct Cons {
-    car: Tag,
-    cdr: Tag,
-}
-
-pub trait Gc {
-    fn gc_ref_image(_: &GcContext, tag: Tag) -> Self;
-    fn ref_car(_: &GcContext, _: Tag) -> Tag;
-    fn ref_cdr(_: &GcContext, _: Tag) -> Tag;
-    fn mark(_: &mut GcContext, _: &Env, _: Tag);
-}
-
-impl Gc for Cons {
-    fn gc_ref_image(context: &GcContext, tag: Tag) -> Self {
-        let heap_ref = &context.heap_ref;
-
-        assert_eq!(tag.type_of(), Type::Cons);
-        match tag {
-            Tag::Indirect(main) => Cons {
-                car: Tag::from_slice(
-                    heap_ref
-                        .image_slice(usize::try_from(main.image_id()).unwrap())
-                        .unwrap(),
-                ),
-                cdr: Tag::from_slice(
-                    heap_ref
-                        .image_slice(usize::try_from(main.image_id()).unwrap() + 1)
-                        .unwrap(),
-                ),
-            },
-            Tag::Direct(_) => panic!(),
-        }
-    }
-
-    fn ref_car(context: &GcContext, cons: Tag) -> Tag {
-        match cons.type_of() {
-            Type::Null => cons,
-            Type::Cons => match cons {
-                Tag::Direct(_) => DirectTag::cons_destruct(cons).0,
-                Tag::Indirect(_) => Self::gc_ref_image(context, cons).car,
-            },
-            _ => panic!(),
-        }
-    }
-
-    fn ref_cdr(context: &GcContext, cons: Tag) -> Tag {
-        match cons.type_of() {
-            Type::Null => cons,
-            Type::Cons => match cons {
-                Tag::Indirect(_) => Self::gc_ref_image(context, cons).cdr,
-                Tag::Direct(_) => DirectTag::cons_destruct(cons).1,
-            },
-            _ => panic!(),
-        }
-    }
-
-    fn mark(context: &mut GcContext, env: &Env, cons: Tag) {
-        match cons {
-            Tag::Direct(_) => {
-                let car = Self::ref_car(context, cons);
-                let cdr = Self::ref_cdr(context, cons);
-
-                context.mark(env, car);
-                context.mark(env, cdr);
-            }
-            Tag::Indirect(_) => {
-                let mark = context.mark_image(cons).unwrap();
-                if !mark {
-                    context.mark(env, Self::ref_car(context, cons));
-                    context.mark(env, Self::ref_cdr(context, cons));
-                }
-            }
-        }
-    }
+    pub car: Tag,
+    pub cdr: Tag,
 }
 
 impl Cons {
@@ -188,30 +114,6 @@ impl Cons {
 
         (car, cdr)
     }
-
-    /*
-        pub fn car(env: &Env, cons: Tag) -> Tag {
-            match cons.type_of() {
-                Type::Null => cons,
-                Type::Cons => match cons {
-                    Tag::Direct(_) => DirectTag::cons_deref(cons).0,
-                    Tag::Image(_) | Tag::Indirect(_) => Self::to_image(env, cons).car,
-                },
-                _ => panic!(),
-            }
-        }
-
-        pub fn cdr(env: &Env, cons: Tag) -> Tag {
-            match cons.type_of() {
-                Type::Null => cons,
-                Type::Cons => match cons {
-                    Tag::Direct(_) => DirectTag::cons_deref(cons).1,
-                    Tag::Image(_) | Tag::Indirect(_) => Self::to_image(env, cons).cdr,
-                },
-                _ => panic!(),
-            }
-    }
-        */
 
     pub fn length(env: &Env, cons: Tag) -> Option<usize> {
         match cons.type_of() {

--- a/src/mu/types/function.rs
+++ b/src/mu/types/function.rs
@@ -15,7 +15,6 @@ use {
             type_::Type,
         },
         namespaces::{
-            gc::{Gc as _, GcContext},
             heap::HeapRequest,
         },
         streams::writer::StreamWriter,
@@ -33,50 +32,6 @@ use {
 pub struct Function {
     pub arity: Tag, // number of required arguments
     pub form: Tag,  // list
-}
-
-pub trait Gc {
-    fn ref_form(_: &mut GcContext, _: Tag) -> Tag;
-    fn mark(_: &mut GcContext, _: &Env, _: Tag);
-    fn gc_ref_image(_: &mut GcContext, _: Tag) -> Self;
-}
-
-impl Gc for Function {
-    fn ref_form(context: &mut GcContext, func: Tag) -> Tag {
-        Self::gc_ref_image(context, func).form
-    }
-
-    fn mark(context: &mut GcContext, env: &Env, function: Tag) {
-        let mark = context.mark_image(function).unwrap();
-
-        if !mark {
-            let form = Self::ref_form(context, function);
-
-            context.mark(env, form);
-        }
-    }
-
-    fn gc_ref_image(context: &mut GcContext, tag: Tag) -> Self {
-        assert_eq!(tag.type_of(), Type::Function);
-
-        let heap_ref = &context.heap_ref;
-
-        match tag {
-            Tag::Indirect(fn_) => Self::new(
-                Tag::from_slice(
-                    heap_ref
-                        .image_slice(usize::try_from(fn_.image_id()).unwrap())
-                        .unwrap(),
-                ),
-                Tag::from_slice(
-                    heap_ref
-                        .image_slice(usize::try_from(fn_.image_id()).unwrap() + 1)
-                        .unwrap(),
-                ),
-            ),
-            Tag::Direct(_) => panic!(),
-        }
-    }
 }
 
 impl Function {

--- a/src/mu/types/symbol.rs
+++ b/src/mu/types/symbol.rs
@@ -16,7 +16,6 @@ use {
         },
         namespaces::{
             cache::Cache,
-            gc::{Gc as _, GcContext},
             heap::{Heap, HeapRequest},
             namespace::Namespace,
         },
@@ -42,83 +41,6 @@ pub struct SymbolImage {
     pub namespace: Tag,
     pub name: Tag,
     pub value: Tag,
-}
-
-pub trait Gc {
-    fn gc_ref_image(_: &mut GcContext, tag: Tag) -> SymbolImage;
-    fn ref_name(_: &mut GcContext, symbol: Tag) -> Tag;
-    fn ref_value(_: &mut GcContext, symbol: Tag) -> Tag;
-    fn mark(_: &mut GcContext, env: &Env, symbol: Tag);
-}
-
-impl Gc for Symbol {
-    fn gc_ref_image(context: &mut GcContext, tag: Tag) -> SymbolImage {
-        assert_eq!(tag.type_of(), Type::Symbol);
-
-        match tag {
-            Tag::Indirect(main) => SymbolImage {
-                namespace: Tag::from_slice(
-                    context
-                        .heap_ref
-                        .image_slice(usize::try_from(main.image_id()).unwrap())
-                        .unwrap(),
-                ),
-                name: Tag::from_slice(
-                    context
-                        .heap_ref
-                        .image_slice(usize::try_from(main.image_id()).unwrap() + 1)
-                        .unwrap(),
-                ),
-                value: Tag::from_slice(
-                    context
-                        .heap_ref
-                        .image_slice(usize::try_from(main.image_id()).unwrap() + 2)
-                        .unwrap(),
-                ),
-            },
-            Tag::Direct(_) => panic!(),
-        }
-    }
-
-    fn ref_name(context: &mut GcContext, symbol: Tag) -> Tag {
-        match symbol.type_of() {
-            Type::Null | Type::Keyword => match symbol {
-                Tag::Direct(dir) => DirectTag::to_tag(
-                    dir.data(),
-                    DirectExt::Length(dir.ext() as usize),
-                    DirectType::String,
-                ),
-                Tag::Indirect(_) => panic!(),
-            },
-            Type::Symbol => Self::gc_ref_image(context, symbol).name,
-            _ => panic!(),
-        }
-    }
-
-    fn ref_value(context: &mut GcContext, symbol: Tag) -> Tag {
-        match symbol.type_of() {
-            Type::Null | Type::Keyword => symbol,
-            Type::Symbol => Self::gc_ref_image(context, symbol).value,
-            _ => panic!(),
-        }
-    }
-
-    fn mark(context: &mut GcContext, env: &Env, symbol: Tag) {
-        match symbol {
-            Tag::Direct(_) => (),
-            Tag::Indirect(_) => {
-                let mark = context.mark_image(symbol).unwrap();
-
-                if !mark {
-                    let name = Self::ref_name(context, symbol);
-                    let value = Self::ref_value(context, symbol);
-
-                    context.mark(env, name);
-                    context.mark(env, value);
-                }
-            }
-        }
-    }
 }
 
 impl Symbol {


### PR DESCRIPTION
move all the gc stuff to a separate directory

reduces types and vector sources by a bit

docs: no change
tests: no change
srcs: relocate gc stuff