### PR TITLE
#1101 - runtime: fix size of native function

### DIFF
--- a/src/mu/types/function.rs
+++ b/src/mu/types/function.rs
@@ -133,7 +133,8 @@ impl Function {
             Type::Null | Type::Cons | Type::Vector => std::mem::size_of::<Function>(),
             Type::Symbol => {
                 std::mem::size_of::<Fixnum>() + Symbol::image_size(env, Self::destruct(env, func).1)
-            }
+            },
+            Type::Fixnum => { std::mem::size_of::<Tag>() },
             _ => panic!(),
         }
     }


### PR DESCRIPTION
Need to get correct size of nativce function, even though we'll need to work hard to report anything other that the size of a direct tag.

docs: no change
tests: no change
srcs: amend function size-of function